### PR TITLE
(#5) spring-doc 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Swagger 적용
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 작업 내용

- api 문서를 web으로 제공하기 위해 spring-doc 의존성을 추가하였습니다.

## 핵심 변경 사항

![image](https://user-images.githubusercontent.com/59705184/235351732-a0c4f535-9b95-42da-a30c-20d7a0ccda29.png)

작동 이미지 입니다.

## 테스트 결과

- 테스트 결과 생략

## 닫힌 이슈

close #5

## 리뷰어에게

- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용 작성 가능
