### PR TITLE
(#7) 유저 보안 설정 - Spring Security / JWT 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,15 @@ dependencies {
 
 	// Swagger 적용
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+
+	// Spring Security 적용
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// jwt 적용
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
+	// jpa 적용
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/plana/planb/auth/config/JwtSecurityConfig.java
+++ b/src/main/java/com/plana/planb/auth/config/JwtSecurityConfig.java
@@ -1,0 +1,21 @@
+package com.plana.planb.auth.config;
+import com.plana.planb.auth.config.jwt.JwtFilter;
+import com.plana.planb.auth.config.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+// 직접 만든 TokenProvider 와 JwtFilter 를 SecurityConfig 에 적용할 때 사용
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final TokenProvider tokenProvider;
+
+    // TokenProvider 를 주입받아서 JwtFilter 를 통해 Security 로직에 필터를 등록
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/plana/planb/auth/config/SecurityConfig.java
+++ b/src/main/java/com/plana/planb/auth/config/SecurityConfig.java
@@ -1,0 +1,84 @@
+package com.plana.planb.auth.config;
+
+import com.plana.planb.auth.config.jwt.JwtAccessDeniedHandler;
+import com.plana.planb.auth.config.jwt.JwtAuthenticationEntryPoint;
+import com.plana.planb.auth.config.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain (HttpSecurity http) throws Exception {
+        // CSRF 설정 Disable
+        return http.csrf().disable()
+            .httpBasic().disable()
+            .cors().configurationSource(corsConfigurationSource())
+            .and()
+
+            // exception handling 할 때 우리가 만든 클래스를 추가
+            .exceptionHandling()
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            .accessDeniedHandler(jwtAccessDeniedHandler)
+
+            // 시큐리티는 기본적으로 세션을 사용
+            // 여기서는 세션을 사용하지 않기 때문에 세션 설정을 Stateless 로 설정
+            .and()
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+            // 로그인, 회원가입 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
+            .and()
+            .authorizeRequests()
+            .requestMatchers("/app/deal/{dealId}/detail", "/app/deal/list", "/auth/**").permitAll()
+            .requestMatchers("/app/member/**", "/app/deal/**", "/app/hobby/regist","/app/hobby/history/regist","/app/hobby/favorite/regist/{hobbyId}").authenticated()
+
+            // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용
+            .and()
+            .apply(new JwtSecurityConfig(tokenProvider))
+            .and().build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        //    configuration.addAllowedOrigin("*");
+        configuration.setAllowedOriginPatterns(
+            Arrays.asList("http://localhost:3000",
+                "https://k7a702.p.ssafy.io:3000",
+                "https://k7a702.p.ssafy.io"));
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+}

--- a/src/main/java/com/plana/planb/auth/config/SecurityConfig.java
+++ b/src/main/java/com/plana/planb/auth/config/SecurityConfig.java
@@ -53,8 +53,8 @@ public class SecurityConfig {
             // 로그인, 회원가입 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
             .and()
             .authorizeRequests()
-            .requestMatchers("/app/deal/{dealId}/detail", "/app/deal/list", "/auth/**").permitAll()
-            .requestMatchers("/app/member/**", "/app/deal/**", "/app/hobby/regist","/app/hobby/history/regist","/app/hobby/favorite/regist/{hobbyId}").authenticated()
+            .requestMatchers("/auth/**").permitAll()
+            .requestMatchers("/app/member/**").authenticated()
 
             // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용
             .and()

--- a/src/main/java/com/plana/planb/auth/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/plana/planb/auth/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.plana.planb.auth.config.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        // 필요한 권한이 없이 접근하려 할때 403
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "FORBIDDEN");
+    }
+}

--- a/src/main/java/com/plana/planb/auth/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/plana/planb/auth/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.plana.planb.auth.config.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "UnAuthorized");
+    }
+}

--- a/src/main/java/com/plana/planb/auth/config/jwt/JwtFilter.java
+++ b/src/main/java/com/plana/planb/auth/config/jwt/JwtFilter.java
@@ -1,0 +1,46 @@
+package com.plana.planb.auth.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    // 실제 필터링 로직은 doFilterInternal 에 들어감
+    // JWT 토큰의 인증 정보를 현재 쓰레드의 SecurityContext 에 저장하는 역할 수행
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        // 1. Request Header 에서 토큰을 꺼냄
+        String jwt = resolveToken(request);
+
+        // 2. validateToken 으로 토큰 유효성 검사
+        // 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    // Request Header 에서 토큰 정보를 꺼내오기
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/plana/planb/auth/config/jwt/TokenProvider.java
+++ b/src/main/java/com/plana/planb/auth/config/jwt/TokenProvider.java
@@ -1,6 +1,6 @@
 package com.plana.planb.auth.config.jwt;
 
-import com.plana.planb.auth.dto.TokenDto;
+import com.plana.planb.auth.dto.jwt.TokenDto;
 import com.plana.planb.auth.exception.ex.CustomException;
 import com.plana.planb.auth.exception.ex.ErrorCode;
 import io.jsonwebtoken.Claims;
@@ -13,13 +13,11 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/plana/planb/auth/config/jwt/TokenProvider.java
+++ b/src/main/java/com/plana/planb/auth/config/jwt/TokenProvider.java
@@ -1,0 +1,152 @@
+package com.plana.planb.auth.config.jwt;
+
+import com.plana.planb.auth.dto.TokenDto;
+import com.plana.planb.auth.exception.ex.CustomException;
+import com.plana.planb.auth.exception.ex.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+//    @Value("${jwt.blacklist.access-token}")
+//    private String blackListATPrefix;
+
+//    private final RedisService redisService;
+    private final Key key;
+
+    public TokenProvider() {
+        String secretKey = "c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK";
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+//        this.redisService = redisService;
+    }
+
+    public TokenDto generateTokenDto(Authentication authentication) {
+        // 권한들 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())       // payload "sub": "name"
+                .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
+                .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
+                .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+//        redisService.setValues(authentication.getName(), refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+//        if (claims.get(AUTHORITIES_KEY) == null) {
+//            throw new CustomException(INVALID_ACCESS_TOKEN);
+//        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 리턴
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+//            String expiredAT = redisService.getValues(blackListATPrefix + token);
+//            if (expiredAT != null) {
+//                throw new ExpiredJwtException(null, null, null);
+//            }
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e)  {
+            log.error("accessToken 잘못됨 = {}", e.getMessage());
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+//    public void checkRefreshToken(String memberId, String refreshToken) {
+//        String redisRT = redisService.getValues(memberId);
+//        if (!refreshToken.equals(redisRT)) {
+//            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+//        }
+//    }
+//
+//    private Date getExpiredTime(String token) {
+//        return Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getExpiration();
+//    }
+//
+//    public void logout(String memberId, String accessToken) {
+//        long expiredAccessTokenTime = getExpiredTime(accessToken).getTime() - new Date().getTime();
+//        redisService.setValues(blackListATPrefix + accessToken, memberId, Duration.ofMillis(expiredAccessTokenTime));
+//        redisService.deleteValues(memberId); // Delete RefreshToken In Redis
+//    }
+}

--- a/src/main/java/com/plana/planb/auth/controller/AuthController.java
+++ b/src/main/java/com/plana/planb/auth/controller/AuthController.java
@@ -1,0 +1,73 @@
+package com.plana.planb.auth.controller;
+
+import com.plana.planb.auth.dto.MemberJoinDto;
+import com.plana.planb.auth.dto.MemberLoginDto;
+import com.plana.planb.auth.dto.jwt.TokenDto;
+import com.plana.planb.auth.dto.jwt.TokenRequestDto;
+import com.plana.planb.auth.dto.response.ResponseDto;
+import com.plana.planb.auth.exception.ex.CustomException;
+import com.plana.planb.auth.exception.ex.CustomValidationException;
+import com.plana.planb.auth.exception.ex.ErrorCode;
+import com.plana.planb.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody @Valid MemberJoinDto memberJoinDto, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            Map<String, String> errorMap = new HashMap<>();
+
+            for (FieldError error : bindingResult.getFieldErrors()) {
+                errorMap.put(error.getField(), error.getDefaultMessage());
+            }
+
+            throw new CustomValidationException("유효성 검사 실패", errorMap);
+        } else {
+            if (!memberJoinDto.getPassword().equals(memberJoinDto.getPasswordConfirm())) {
+                throw new CustomException(ErrorCode.NOT_EQUAL_PASSWORD );
+            }
+            return new ResponseEntity<ResponseDto>(new ResponseDto(200, "회원가입 성공",
+                    authService.signup(memberJoinDto)), HttpStatus.OK);
+        }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody MemberLoginDto memberLoginDto) {
+        TokenDto token = authService.login(memberLoginDto);
+        return new ResponseEntity<ResponseDto>(new ResponseDto<>(200, "로그인 성공",
+                token), HttpStatus.OK);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@RequestBody TokenRequestDto tokenRequestDto) {
+        return new ResponseEntity<ResponseDto>(new ResponseDto<>(200, "토큰 재발행",
+                authService.reissue(tokenRequestDto)), HttpStatus.OK);
+    }
+
+    @GetMapping("/logout")
+    public ResponseEntity logout(HttpServletRequest request) {
+        String accessToken = request.getHeader("Authorization").substring(7);
+//        authService.logout(accessToken);
+        return new ResponseEntity<>(new ResponseDto<>(200, "로그아웃 완료", null)
+                , HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/plana/planb/auth/domain/BaseEntity.java
+++ b/src/main/java/com/plana/planb/auth/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.plana.planb.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+
+}

--- a/src/main/java/com/plana/planb/auth/domain/Member.java
+++ b/src/main/java/com/plana/planb/auth/domain/Member.java
@@ -1,0 +1,53 @@
+package com.plana.planb.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.ArrayList;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@Getter
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String email;
+
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(unique = true)
+    private String nickname;
+
+    private String certificate;
+
+    private String profileImage;
+
+    public void changeProfileImage(String profileImage){
+        this.profileImage = profileImage;
+    }
+
+    public void changeMemberId(Long memberId) {
+        this.id = memberId;
+    }
+
+    public void profileModify(String profileImage, String nickname) {
+        this.profileImage = profileImage;
+        this.nickname = nickname;
+    }
+
+}

--- a/src/main/java/com/plana/planb/auth/dto/MemberJoinDto.java
+++ b/src/main/java/com/plana/planb/auth/dto/MemberJoinDto.java
@@ -1,0 +1,53 @@
+package com.plana.planb.auth.dto;
+
+import com.plana.planb.auth.domain.Member;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberJoinDto {
+
+    @NotBlank
+    private String name;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,20}$",
+            message = "비밀번호는 8~20자리수여야 합니다. 영문 대소문자, 숫자, 특수문자를 1개 이상 포함해야 합니다.")
+    private String password;
+
+    @NotBlank
+    private String passwordConfirm;
+
+    @NotBlank
+    @Size(min = 3, max = 30, message = "닉네임은 3~30자리수여야 합니다.")
+    private String nickName;
+
+    public Member toMember(PasswordEncoder passwordEncoder) {
+        return Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .name(name)
+                .nickname(nickName)
+                .build();
+    }
+
+    public UsernamePasswordAuthenticationToken toAuthentication() {
+        return new UsernamePasswordAuthenticationToken(email, password);
+    }
+
+}

--- a/src/main/java/com/plana/planb/auth/dto/MemberJoinResponseDto.java
+++ b/src/main/java/com/plana/planb/auth/dto/MemberJoinResponseDto.java
@@ -1,0 +1,16 @@
+package com.plana.planb.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberJoinResponseDto {
+
+    private String email;
+
+}

--- a/src/main/java/com/plana/planb/auth/dto/MemberLoginDto.java
+++ b/src/main/java/com/plana/planb/auth/dto/MemberLoginDto.java
@@ -1,0 +1,19 @@
+package com.plana.planb.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class MemberLoginDto {
+
+    private String email;
+    private String password;
+
+    public UsernamePasswordAuthenticationToken toAuthentication() {
+        return new UsernamePasswordAuthenticationToken(email, password);
+    }
+}

--- a/src/main/java/com/plana/planb/auth/dto/TokenDto.java
+++ b/src/main/java/com/plana/planb/auth/dto/TokenDto.java
@@ -1,0 +1,18 @@
+package com.plana.planb.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@Data
+public class TokenDto {
+    private String nickname;
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+}

--- a/src/main/java/com/plana/planb/auth/dto/jwt/TokenDto.java
+++ b/src/main/java/com/plana/planb/auth/dto/jwt/TokenDto.java
@@ -1,4 +1,4 @@
-package com.plana.planb.auth.dto;
+package com.plana.planb.auth.dto.jwt;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/plana/planb/auth/dto/jwt/TokenRequestDto.java
+++ b/src/main/java/com/plana/planb/auth/dto/jwt/TokenRequestDto.java
@@ -1,0 +1,15 @@
+package com.plana.planb.auth.dto.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@Data
+public class TokenRequestDto {
+    String accessToken;
+    String refreshToken;
+}

--- a/src/main/java/com/plana/planb/auth/dto/response/ResponseDto.java
+++ b/src/main/java/com/plana/planb/auth/dto/response/ResponseDto.java
@@ -1,0 +1,16 @@
+package com.plana.planb.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ResponseDto<T> {
+
+    private int status;
+    private String message;
+    private T data;
+
+}

--- a/src/main/java/com/plana/planb/auth/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/plana/planb/auth/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.plana.planb.auth.exception;
+
+import com.plana.planb.auth.dto.response.ResponseDto;
+import com.plana.planb.auth.exception.ex.CustomException;
+import com.plana.planb.auth.exception.ex.CustomValidationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomValidationException.class)
+    public ResponseEntity<?> customValidation(CustomValidationException e) {
+
+        return new ResponseEntity<ResponseDto>(new ResponseDto(400, e.getMessage(),
+
+                e.getErrorMap()), HttpStatus.BAD_REQUEST);
+
+    }
+
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> customException(CustomException e) {
+
+        return new ResponseEntity<>(new ResponseDto(e.getErrorCode().getStatus(), e.getErrorCode().getMessage(), null),
+
+                HttpStatus.valueOf(e.getErrorCode().getStatus()));
+
+    }
+
+}

--- a/src/main/java/com/plana/planb/auth/exception/ex/CustomException.java
+++ b/src/main/java/com/plana/planb/auth/exception/ex/CustomException.java
@@ -1,0 +1,12 @@
+package com.plana.planb.auth.exception.ex;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+}

--- a/src/main/java/com/plana/planb/auth/exception/ex/CustomValidationException.java
+++ b/src/main/java/com/plana/planb/auth/exception/ex/CustomValidationException.java
@@ -1,0 +1,18 @@
+package com.plana.planb.auth.exception.ex;
+
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class CustomValidationException extends RuntimeException{
+
+    private String message;
+    private Map<String, String> errorMap;
+
+
+    public CustomValidationException(String message, Map<String, String> errorMap) {
+        this.message = message;
+        this.errorMap = errorMap;
+    }
+
+}

--- a/src/main/java/com/plana/planb/auth/exception/ex/ErrorCode.java
+++ b/src/main/java/com/plana/planb/auth/exception/ex/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.plana.planb.auth.exception.ex;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+
+    // 400
+    NOT_EQUAL_PASSWORD(400, "비밀번호가 서로 일치하지 않습니다"),
+
+    // 401
+    INVALID_REFRESH_TOKEN(401, "유효하지 않은 RefreshToken 입니다."),
+    INVALID_ACCESS_TOKEN(401, "유효하지 않은 accessToken 입니다."),
+
+    // 403
+    FILE_UPLOAD_ERROR(403, "파일 업로드에 실패하였습니다"),
+
+    // 404 NOT FOUND 잘못된 리소스 접근
+    MEMBER_NOT_FOUND(404, "존재하지 않은 회원 ID 입니다."),
+    MEMBER_EMAIL_NOT_FOUND(404, "존재하지 않은 이메일입니다."),
+
+    //409 CONFLICT 중복된 리소스
+    ALREADY_SAVED_MEMBER(409, "이미 가입되어 있는 회원입니다."),
+    ALREADY_USED_NICKNAME(409, "이미 사용중인 닉네임입니다.");
+
+    private final int status;
+    private final String message;
+
+    }

--- a/src/main/java/com/plana/planb/auth/repository/MemberRepository.java
+++ b/src/main/java/com/plana/planb/auth/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.plana.planb.auth.repository;
+
+import com.plana.planb.auth.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByNickname(String nickname);
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+}
+

--- a/src/main/java/com/plana/planb/auth/service/AuthService.java
+++ b/src/main/java/com/plana/planb/auth/service/AuthService.java
@@ -1,0 +1,118 @@
+package com.plana.planb.auth.service;
+
+import com.plana.planb.auth.config.jwt.TokenProvider;
+import com.plana.planb.auth.domain.Member;
+import com.plana.planb.auth.dto.MemberJoinDto;
+import com.plana.planb.auth.dto.MemberJoinResponseDto;
+import com.plana.planb.auth.dto.MemberLoginDto;
+import com.plana.planb.auth.dto.jwt.TokenDto;
+import com.plana.planb.auth.dto.jwt.TokenRequestDto;
+import com.plana.planb.auth.exception.ex.CustomException;
+import com.plana.planb.auth.exception.ex.ErrorCode;
+import com.plana.planb.auth.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+//    private final AwsS3Service awsS3Service;
+
+//    private final RedisService redisService;
+
+    /**
+     * 회원가입
+     */
+    @Transactional
+    public MemberJoinResponseDto signup(MemberJoinDto memberJoinDto) {
+        if(memberRepository.existsByEmail(memberJoinDto.getEmail())){
+            throw new CustomException(ErrorCode.ALREADY_SAVED_MEMBER);
+        }
+
+        Member member = memberJoinDto.toMember(passwordEncoder);
+//        member.changeProfileImage(randomProfileImage());
+        memberRepository.save(member);
+
+//        redisService.setValues(String.valueOf(member.getId()) + ".", member.getNickname());
+        return new MemberJoinResponseDto(member.getEmail());
+    }
+
+    /**
+     * 로그인
+     */
+    @Transactional
+    public TokenDto login(MemberLoginDto memberLoginDto){
+        // 1. Login ID/PW 를 기반으로 AuthenticationToken 생성
+        UsernamePasswordAuthenticationToken authenticationToken = memberLoginDto.toAuthentication();
+
+        Member member = memberRepository.findByEmail(memberLoginDto.getEmail()).orElseThrow(() ->
+                new CustomException(ErrorCode.MEMBER_EMAIL_NOT_FOUND));
+
+        // 2. 실제로 검증 (사용자 비밀번호 체크) 이 이루어지는 부분
+        //    authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        tokenDto.setNickname(member.getNickname());
+        // 5. 토큰 발급
+        return tokenDto;
+    }
+
+    /**
+     * 토큰 재발행
+     */
+    @Transactional
+    public TokenDto reissue(TokenRequestDto tokenRequestDto){
+        // 1. Refresh Token 검증
+        if (!tokenProvider.validateToken(tokenRequestDto.getRefreshToken())) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+
+        // 2. Access Token 에서 Member ID 가져오기
+        Authentication authentication = tokenProvider.getAuthentication(tokenRequestDto.getRefreshToken());
+
+        // redis에 있는 refreshToken과 비교
+//        tokenProvider.checkRefreshToken(authentication.getName(), tokenRequestDto.getRefreshToken());
+
+        Member member = memberRepository.findById(Long.parseLong(authentication.getName())).orElseThrow(() ->
+                new CustomException(ErrorCode.MEMBER_EMAIL_NOT_FOUND));
+
+        // 5. 새로운 토큰 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        tokenDto.setNickname(member.getNickname());
+
+        // 토큰 발급
+        return tokenDto;
+    }
+
+    /**
+     * 로그아웃
+     */
+//    @Transactional
+//    public void logout(String accessToken) {
+//        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+//        tokenProvider.logout(authentication.getName(), accessToken);
+//    }
+
+    /**
+     * 랜덤 프로필 이미지
+     */
+//    public String randomProfileImage(){
+//        int random = (int) (Math.random() * 6) + 1;
+//        String path = "member/default/" + random + ".jpg";
+//        String thumbnailPath = awsS3Service.getThumbnailPath(path);
+//        return thumbnailPath;
+//    }
+}


### PR DESCRIPTION
## 작업 내용

- Spring Security와 jwt를 사용하여 유저 보안 설정 추가 (API 및 기능)
- 로그인, 회원가입, 로그아웃, 토큰 재발행 MVC 구현

## 핵심 변경 사항
![image](https://github.com/Plan-A-project/Plan-A-server/assets/68692871/76a42e6a-56d3-49b3-bfe6-ee23a96172fe)

## 테스트 결과

- 테스트 결과 위 Swagger 이미지와 같음

## 닫힌 이슈

close #7
close #8
close #9
close #10 

## 리뷰어에게

- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용 작성 가능
